### PR TITLE
bug fixes

### DIFF
--- a/td_client_actor.js
+++ b/td_client_actor.js
@@ -38,7 +38,7 @@ const { inspect } = require('util')
 
 class TdClientActor extends EventEmitter {
     /**
-     * @param {TdClientActorOptions} options 
+     * @param {TdClientActorOptions} options
      */
     constructor(options) {
         // @ts-ignore
@@ -220,14 +220,14 @@ class TdClientActor extends EventEmitter {
     /**
      * Poll for updates
      * @private
-     * @param {number} timeout 
-     * @param {boolean} is_recursive 
+     * @param {number} timeout
+     * @param {boolean} is_recursive
      */
     _pollUpdates(timeout = 5, is_recursive = false) {
         if (is_recursive && this._closed) {
             console.log('Client closed. Stopping recursive update.')
         }
-        if (this._closed) throw new Error('is closed')
+        if (this._closed) {return;}
         if (this._options.polling_mode === 'async') {
             lib.td_client_receive_async(this._instance_id, timeout, (err, res) => {
                 if (err) {
@@ -407,7 +407,7 @@ class TdClientActor extends EventEmitter {
 
     _isCacheableUpdate(key) {
         return this._options.use_cache && [
-            'updateNewChat', 
+            'updateNewChat',
             'updateUser',
             'updateBasicGroup',
             'updateSupergroup',
@@ -507,7 +507,7 @@ class TdClientActor extends EventEmitter {
             cache.reply_markup_message_id = data.reply_markup_message_id
         } else if (name === 'updateChatDraftMessage') {
             const cache = this._cache.get(`chat:${data.chat_id}`)
-            cache.draft_message = data.draft_message        
+            cache.draft_message = data.draft_message
             cache.order = data.order
         } else if (name === 'updateChatNotificationSettings') {
             const cache = this._cache.get(`chat:${data.chat_id}`)

--- a/td_client_actor.js
+++ b/td_client_actor.js
@@ -207,14 +207,9 @@ class TdClientActor extends EventEmitter {
      * @fires TdClientActor#destroy
      */
     destroy() {
-        return new Promise((rs, rj) => {
-            if (this._closed) rj(new Error('Already closed.'))
-            this._closed = true
-            this.once('closed', () => {
-                rs()
-            })
-            setImmediate(lib.td_client_destroy, this._instance_id)
-        })
+        if (this._closed) throw new Error('Already closed.');
+        this._closed = true;
+        setImmediate(lib.td_client_destroy, this._instance_id)
     }
 
     /**


### PR DESCRIPTION
Hi, I've fixed a couple of bugs.

**1. Fixed logic of `destroy` method:**

It's [known](https://github.com/tdlib/td/issues/594), that `td_json_client_destroy` should be called after `authorizationStateClosed` is received. So there is no need to wait for `closed` event, `destroy` method should be called after this event is received.

**2. Fixed `_pollUpdates` method:**

There is no need to throw an exception because it's uncatchable, so it crashes an application. It's enough to just stop receiving updates.