### PR TITLE
Building process optimisation & fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ test.js
 *.node
 
 build/
+
+td

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "td"]
-	path = td
-	url = https://github.com/tdlib/td.git

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ List of prebuilt binary is available [here](https://github.com/wfjsw/node-tdlib/
 ### Compile on your own
 
 ```
-git clone https://github.com/wfjsw/node-tdlib.git --recurse-submodules
+git clone https://github.com/wfjsw/node-tdlib.git
 cd node-tdlib
 npm i
 npm run compile

--- a/build_binary.js
+++ b/build_binary.js
@@ -1,25 +1,31 @@
 // @ts-nocheck
 const fs = require('fs')
-const cp = require('child_process')
-const { tdlib } = require('./package.json')
+const {spawn, execSync} = require('child_process');
+const {tdlib} = require('./package.json')
 
 console.log('Downloading tdlib...')
 
-cp.execSync('rm -fR td && git clone https://github.com/tdlib/td.git && cd td && git checkout ' + tdlib.commit + ' && cd ../', {stdio: 'ignore'})
+execSync('git clone https://github.com/tdlib/td.git && cd td && git checkout ' + tdlib.commit + ' && cd ../', {stdio: 'ignore'})
 
 console.log('Launching compiler, please wait...')
 
-let cmdline = 'cmake-js compile -C'
-if (tdlib.debug) cmdline += ' -D'
+let cmd = 'cmake-js'
+let cmdOptions = ['compile', '-C']
+if (tdlib.debug) cmdOptions.push('-D')
 
-cp.execSync(cmdline)
+let cmakeJs = spawn(cmd, cmdOptions)
+cmakeJs.stdout.on('data', (data) => console.log(data.toString()))
+cmakeJs.stderr.on('data', (data) => console.error(data.toString()))
+cmakeJs.on('exit', function (code) {
+    if (code === 0) {
+        console.log('Moving artifact into correct location...')
 
-console.log('Moving artifact into correct location...')
+        fs.renameSync(`./build/${tdlib.debug ? 'Debug' : 'Release'}/tdlib.node`, './tdlib.node')
+    }
 
-fs.renameSync(`./build/${tdlib.debug ? 'Debug' : 'Release'}/tdlib.node`, './tdlib.node')
+    console.log('Cleaning up...')
 
-console.log('Cleaning up...')
+    execSync('rm -fR build && rm -fR td', {stdio: 'ignore'})
 
-cp.execSync('rm -fR build && rm -fR td', {stdio: 'ignore'})
-
-process.exit(0)
+    process.exit(0)
+})

--- a/build_binary.js
+++ b/build_binary.js
@@ -3,6 +3,10 @@ const fs = require('fs')
 const cp = require('child_process')
 const { tdlib } = require('./package.json')
 
+console.log('Downloading tdlib...')
+
+cp.execSync('rm -fR td && git clone https://github.com/tdlib/td.git && cd td && git checkout ' + tdlib.commit + ' && cd ../', {stdio: 'ignore'})
+
 console.log('Launching compiler, please wait...')
 
 let cmdline = 'cmake-js compile -C'
@@ -13,5 +17,9 @@ cp.execSync(cmdline)
 console.log('Moving artifact into correct location...')
 
 fs.renameSync(`./build/${tdlib.debug ? 'Debug' : 'Release'}/tdlib.node`, './tdlib.node')
+
+console.log('Cleaning up...')
+
+cp.execSync('rm -fR build && rm -fR td', {stdio: 'ignore'})
 
 process.exit(0)

--- a/build_binary.js
+++ b/build_binary.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const fs = require('fs')
-const {spawn, execSync} = require('child_process');
-const {tdlib} = require('./package.json')
+const { spawn, execSync } = require('child_process')
+const { tdlib } = require('./package.json')
 
 console.log('Downloading tdlib...')
 

--- a/td_client_actor.js
+++ b/td_client_actor.js
@@ -38,7 +38,7 @@ const { inspect } = require('util')
 
 class TdClientActor extends EventEmitter {
     /**
-     * @param {TdClientActorOptions} options 
+     * @param {TdClientActorOptions} options
      */
     constructor(options) {
         // @ts-ignore
@@ -220,14 +220,14 @@ class TdClientActor extends EventEmitter {
     /**
      * Poll for updates
      * @private
-     * @param {number} timeout 
-     * @param {boolean} is_recursive 
+     * @param {number} timeout
+     * @param {boolean} is_recursive
      */
     _pollUpdates(timeout = 5, is_recursive = false) {
         if (is_recursive && this._closed) {
             console.log('Client closed. Stopping recursive update.')
         }
-        if (this._closed) throw new Error('is closed')
+        if (this._closed) {return;}
         if (this._options.polling_mode === 'async') {
             lib.td_client_receive_async(this._instance_id, timeout, (err, res) => {
                 if (err) {
@@ -407,7 +407,7 @@ class TdClientActor extends EventEmitter {
 
     _isCacheableUpdate(key) {
         return this._options.use_cache && [
-            'updateNewChat', 
+            'updateNewChat',
             'updateUser',
             'updateBasicGroup',
             'updateSupergroup',
@@ -507,7 +507,7 @@ class TdClientActor extends EventEmitter {
             cache.reply_markup_message_id = data.reply_markup_message_id
         } else if (name === 'updateChatDraftMessage') {
             const cache = this._cache.get(`chat:${data.chat_id}`)
-            cache.draft_message = data.draft_message        
+            cache.draft_message = data.draft_message
             cache.order = data.order
         } else if (name === 'updateChatNotificationSettings') {
             const cache = this._cache.get(`chat:${data.chat_id}`)

--- a/td_client_actor.js
+++ b/td_client_actor.js
@@ -207,14 +207,9 @@ class TdClientActor extends EventEmitter {
      * @fires TdClientActor#destroy
      */
     destroy() {
-        return new Promise((rs, rj) => {
-            if (this._closed) rj(new Error('Already closed.'))
-            this._closed = true
-            this.once('closed', () => {
-                rs()
-            })
-            setImmediate(lib.td_client_destroy, this._instance_id)
-        })
+        if (this._closed) throw new Error('Already closed.');
+        this._closed = true;
+        setImmediate(lib.td_client_destroy, this._instance_id)
     }
 
     /**


### PR DESCRIPTION
I've made some changes to the building process:

**1. Removed `tdlib` as git module**
NPM can't load git modules, so compilation didn't work if compiled tdlib binary hadn't been found. Now, `build_binary.js` will clone tdlib into td, checkout actual commit in accordance with `package.json` and build it.
**2. Added cleaning operation**
Now, `build_binary.js` will remove `build` and `td` folders after finishing its work.
**3. Replaced `execSync` with `spawn`**
I replaced `execSync` with `spawn` in order to see compilation logs during a compilation process.